### PR TITLE
Add greeting section and policy detail page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -120,11 +120,30 @@ img { max-width: 100%; height: auto; }
 .card { background: var(--white); padding: 20px; border-radius: var(--border-radius); box-shadow: var(--shadow); transition: 0.3s; }
 .card:hover { transform: translateY(-5px); }
 
+/* Greeting */
+.greeting-section { background-color: var(--bg-light); }
+.greeting-wrapper { display: flex; gap: 40px; align-items: center; justify-content: space-between; }
+.greeting-text { flex: 2; }
+.greeting-message { color: var(--text-color); font-size: 1rem; line-height: 1.8; }
+.greeting-image { flex: 1; display: flex; justify-content: center; }
+.greeting-img-tag { width: 240px; height: 240px; object-fit: cover; border-radius: 50%; box-shadow: var(--shadow); }
+
 /* Vision */
-.vision-card { text-align: center; }
+.vision-card { text-align: center; display: flex; flex-direction: column; height: 100%; }
 .vision-icon { width: 60px; height: 60px; background: var(--primary-color); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem; font-weight: bold; margin: 0 auto 15px; }
 .vision-card h3 { margin-bottom: 15px; color: var(--primary-color); }
-.vision-card ul { text-align: left; padding-left: 20px; list-style: disc; }
+.vision-card ul { text-align: left; padding-left: 20px; list-style: disc; flex: 1; }
+.vision-link { margin-top: 20px; align-self: center; }
+
+/* Policy Page */
+.page-hero { padding-top: 140px; padding-bottom: 60px; background: #e8f5e9; }
+.page-title { font-size: 2.4rem; color: var(--primary-color); margin-bottom: 20px; }
+.page-lead { font-size: 1.1rem; color: var(--text-light); margin-bottom: 30px; }
+.policy-anchors { display: flex; gap: 15px; flex-wrap: wrap; }
+.policy-section { padding-top: 60px; padding-bottom: 60px; }
+.policy-text { font-size: 1rem; color: var(--text-color); margin-bottom: 20px; }
+.policy-list { padding-left: 20px; list-style: disc; color: var(--text-color); display: grid; gap: 12px; }
+.policy-list li strong { color: var(--primary-color); }
 
 /* Works Tabs */
 .tabs { display: flex; justify-content: center; margin-bottom: 30px; gap: 10px; }
@@ -178,8 +197,11 @@ img { max-width: 100%; height: auto; }
     .timeline::before { width: 4px; height: 100%; left: 20px; top: 0; transform: none; }
     .timeline-item { width: 100%; margin-bottom: 20px; margin-left: 40px; width: calc(100% - 40px); text-align: left; }
     .profile-wrapper { flex-direction: column; gap: 20px; }
+    .greeting-wrapper { flex-direction: column; text-align: left; }
     .profile-details dl { grid-template-columns: 1fr; }
     .grid-4, .grid-3 { grid-template-columns: 1fr; }
+    .policy-anchors { justify-content: flex-start; }
+    .page-title { font-size: 2rem; }
     .footer-content { flex-direction: column; text-align: center; gap: 30px; }
     .footer-links { text-align: center; }
 }

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 <ul>
                     <li><a href="#hero">トップ</a></li>
                     <li><a href="#profile">プロフィール</a></li>
-                    <li><a href="#vision">政策</a></li>
+                    <li><a href="policy.html">政策</a></li>
                     <li><a href="#works">実績</a></li>
                     <li><a href="#news">活動報告</a></li>
                     <li><a href="#support">応援</a></li>
@@ -94,6 +94,24 @@
         </div>
     </section>
 
+    <section id="greeting" class="section bg-light greeting-section">
+        <div class="container greeting-wrapper">
+            <div class="greeting-text">
+                <h2 class="section-title text-left">ご挨拶</h2>
+                <p class="greeting-message">
+                    日頃より温かいご支援を賜り、心より感謝申し上げます。<br>
+                    私は「現場から動かす県政」を信条に、子育て世代や働く世代の声を丁寧に汲み取り、<br>
+                    ひとつひとつの課題に向き合ってまいりました。<br>
+                    これからも橋本から和歌山の未来を切り拓くため、皆さまの声を力に全力で走り続けます。
+                </p>
+            </div>
+            <div class="greeting-image">
+                <img src="images/profile.jpg" alt="小西政宏 ご挨拶写真" class="greeting-img-tag" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex'">
+                <div class="img-placeholder" style="display:none;">写真</div>
+            </div>
+        </div>
+    </section>
+
     <section id="profile" class="section bg-light">
         <div class="container">
             <div class="profile-wrapper">
@@ -139,6 +157,7 @@
                         <li>保育の質向上と待機児童ゼロ</li>
                         <li>多様な学びの場づくり</li>
                     </ul>
+                    <a href="policy.html#policy-education" class="btn btn-secondary vision-link">詳しく見る</a>
                 </div>
                 <div class="card vision-card">
                     <div class="vision-icon">職</div>
@@ -148,6 +167,7 @@
                         <li>企業誘致による雇用創出</li>
                         <li>観光資源の磨き上げ</li>
                     </ul>
+                    <a href="policy.html#policy-economy" class="btn btn-secondary vision-link">詳しく見る</a>
                 </div>
                 <div class="card vision-card">
                     <div class="vision-icon">革</div>
@@ -157,6 +177,7 @@
                         <li>議員定数・報酬の適正化</li>
                         <li>DX推進による行政効率化</li>
                     </ul>
+                    <a href="policy.html#policy-reform" class="btn btn-secondary vision-link">詳しく見る</a>
                 </div>
                 <div class="card vision-card">
                     <div class="vision-icon">声</div>
@@ -166,6 +187,7 @@
                         <li>SNSを活用した広聴機能強化</li>
                         <li>投票しやすい環境整備</li>
                     </ul>
+                    <a href="policy.html#policy-nextgen" class="btn btn-secondary vision-link">詳しく見る</a>
                 </div>
             </div>
         </div>

--- a/js/script.js
+++ b/js/script.js
@@ -6,24 +6,27 @@ document.addEventListener('DOMContentLoaded', () => {
     const navMenu = document.querySelector('.nav-menu');
     const navLinks = document.querySelectorAll('.nav-menu a');
 
-    hamburger.addEventListener('click', () => {
-        const isExpanded = hamburger.getAttribute('aria-expanded') === 'true';
-        hamburger.setAttribute('aria-expanded', !isExpanded);
-        hamburger.classList.toggle('active');
-        navMenu.classList.toggle('active');
-        
-        if(navMenu.classList.contains('active')){
-            hamburger.querySelector('.bar:nth-child(1)').style.transform = 'rotate(45deg) translate(5px, 5px)';
-            hamburger.querySelector('.bar:nth-child(2)').style.opacity = '0';
-            hamburger.querySelector('.bar:nth-child(3)').style.transform = 'rotate(-45deg) translate(5px, -5px)';
-        } else {
-            hamburger.querySelectorAll('.bar').forEach(bar => bar.style.transform = 'none');
-            hamburger.querySelector('.bar:nth-child(2)').style.opacity = '1';
-        }
-    });
+    if (hamburger && navMenu) {
+        hamburger.addEventListener('click', () => {
+            const isExpanded = hamburger.getAttribute('aria-expanded') === 'true';
+            hamburger.setAttribute('aria-expanded', !isExpanded);
+            hamburger.classList.toggle('active');
+            navMenu.classList.toggle('active');
+            
+            if(navMenu.classList.contains('active')){
+                hamburger.querySelector('.bar:nth-child(1)').style.transform = 'rotate(45deg) translate(5px, 5px)';
+                hamburger.querySelector('.bar:nth-child(2)').style.opacity = '0';
+                hamburger.querySelector('.bar:nth-child(3)').style.transform = 'rotate(-45deg) translate(5px, -5px)';
+            } else {
+                hamburger.querySelectorAll('.bar').forEach(bar => bar.style.transform = 'none');
+                hamburger.querySelector('.bar:nth-child(2)').style.opacity = '1';
+            }
+        });
+    }
 
     navLinks.forEach(link => {
         link.addEventListener('click', () => {
+            if (!hamburger || !navMenu) return;
             hamburger.classList.remove('active');
             navMenu.classList.remove('active');
             hamburger.setAttribute('aria-expanded', 'false');
@@ -90,28 +93,30 @@ document.addEventListener('DOMContentLoaded', () => {
     const modalDate = document.getElementById('modal-date-text');
     const modalBody = document.getElementById('modal-body-text');
 
-    newsCards.forEach(card => {
-        card.addEventListener('click', () => {
-            const title = card.querySelector('.news-title').textContent;
-            const date = card.querySelector('.news-date').textContent;
-            const detailText = "（詳細記事サンプル）\n\nここに記事の全文が入ります。クリックされた記事タイトルは「" + title + "」です。\n\n橋本市での活動を通して、地域の皆様から頂いた声を形にするため、日々奔走しております。";
+    if (modal && modalClose && modalTitle && modalDate && modalBody && newsCards.length > 0) {
+        newsCards.forEach(card => {
+            card.addEventListener('click', () => {
+                const title = card.querySelector('.news-title').textContent;
+                const date = card.querySelector('.news-date').textContent;
+                const detailText = "（詳細記事サンプル）\n\nここに記事の全文が入ります。クリックされた記事タイトルは「" + title + "」です。\n\n橋本市での活動を通して、地域の皆様から頂いた声を形にするため、日々奔走しております。";
 
-            modalTitle.textContent = title;
-            modalDate.textContent = date;
-            modalBody.textContent = detailText;
-            modal.classList.add('active');
-            modal.setAttribute('aria-hidden', 'false');
+                modalTitle.textContent = title;
+                modalDate.textContent = date;
+                modalBody.textContent = detailText;
+                modal.classList.add('active');
+                modal.setAttribute('aria-hidden', 'false');
+            });
         });
-    });
 
-    const closeModal = () => {
-        modal.classList.remove('active');
-        modal.setAttribute('aria-hidden', 'true');
-    };
-    modalClose.addEventListener('click', closeModal);
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) closeModal();
-    });
+        const closeModal = () => {
+            modal.classList.remove('active');
+            modal.setAttribute('aria-hidden', 'true');
+        };
+        modalClose.addEventListener('click', closeModal);
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) closeModal();
+        });
+    }
 
     // 6. フォーム送信処理（ダミー）
     const forms = document.querySelectorAll('form');

--- a/policy.html
+++ b/policy.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>政策・ビジョン 詳細 | 小西政宏 和歌山県議会議員</title>
+    <meta name="description" content="小西政宏の政策・ビジョン詳細ページ。子ども・教育、地域経済・仕事、行財政改革、次世代の声を県政へ。">
+
+    <meta property="og:title" content="政策・ビジョン 詳細 | 小西政宏">
+    <meta property="og:description" content="和歌山県議会議員 小西政宏の政策詳細。地域課題に寄り添う具体策をご覧ください。">
+    <meta property="og:image" content="https://example.com/images/ogp.jpg">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="js/script.js" defer></script>
+</head>
+<body class="policy-page">
+
+    <header class="header">
+        <div class="header-container">
+            <h1 class="logo">
+                <a href="index.html">小西政宏<span class="logo-sub">和歌山県議会議員</span></a>
+            </h1>
+            <button class="hamburger" aria-label="メニューを開く" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <ul>
+                    <li><a href="index.html#hero">トップ</a></li>
+                    <li><a href="index.html#profile">プロフィール</a></li>
+                    <li><a href="policy.html">政策</a></li>
+                    <li><a href="index.html#works">実績</a></li>
+                    <li><a href="index.html#news">活動報告</a></li>
+                    <li><a href="index.html#support">応援</a></li>
+                    <li><a href="index.html#contact">お問い合わせ</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section class="section page-hero">
+        <div class="container">
+            <h1 class="page-title">政策・ビジョン 詳細</h1>
+            <p class="page-lead">
+                子どもたちの未来、働く世代の暮らし、行政の効率化、そして次世代の声まで。
+                4つの柱を具体的な行動に落とし込み、和歌山の成長を進めます。
+            </p>
+            <div class="policy-anchors">
+                <a href="#policy-education" class="btn btn-primary">教育</a>
+                <a href="#policy-economy" class="btn btn-primary">経済</a>
+                <a href="#policy-reform" class="btn btn-primary">行革</a>
+                <a href="#policy-nextgen" class="btn btn-primary">次世代</a>
+            </div>
+        </div>
+    </section>
+
+    <section id="policy-education" class="section policy-section">
+        <div class="container">
+            <h2 class="section-title text-left">子ども・教育</h2>
+            <p class="policy-text">
+                子育て世代の負担を減らし、子どもたちの可能性を広げるために、<strong>「教育の質」と「安心の土台」</strong>を両輪で整えます。
+            </p>
+            <ul class="policy-list">
+                <li><strong>教育費の負担軽減:</strong> 給食費や教材費の支援を拡充し、家庭の経済的負担を減らします。</li>
+                <li><strong>保育の質向上:</strong> 保育士の処遇改善と人員確保で、待機児童ゼロと安心の保育体制を実現します。</li>
+                <li><strong>多様な学び:</strong> ICT教育、特別支援教育、フリースクールとの連携を通じて学びの選択肢を増やします。</li>
+            </ul>
+        </div>
+    </section>
+
+    <section id="policy-economy" class="section bg-light policy-section">
+        <div class="container">
+            <h2 class="section-title text-left">地域経済・仕事</h2>
+            <p class="policy-text">
+                地域の働く場を守り、次の世代が地元で暮らせる経済基盤を築きます。
+                <strong>「稼ぐ力」と「暮らしの豊かさ」</strong>をセットで強化します。
+            </p>
+            <ul class="policy-list">
+                <li><strong>中小企業・農林業支援:</strong> 設備投資や販路拡大への補助を拡充し、稼ぐ力を後押しします。</li>
+                <li><strong>企業誘致と雇用:</strong> 物流・IT・観光の成長分野で企業誘致を進め、地元での雇用を創出します。</li>
+                <li><strong>観光資源の磨き上げ:</strong> 高野山麓の魅力発信、周遊型観光の整備で地域経済を循環させます。</li>
+            </ul>
+        </div>
+    </section>
+
+    <section id="policy-reform" class="section policy-section">
+        <div class="container">
+            <h2 class="section-title text-left">行財政改革</h2>
+            <p class="policy-text">
+                税金の使い道を見える化し、ムダを削減することで、未来への投資を増やします。
+                <strong>「スピード」と「透明性」</strong>を重視した改革を進めます。
+            </p>
+            <ul class="policy-list">
+                <li><strong>徹底したムダ削減:</strong> 事業評価を厳格化し、効果の薄い事業は大胆に見直します。</li>
+                <li><strong>議会改革:</strong> 議員定数・報酬の適正化を議論し、開かれた議会運営を推進します。</li>
+                <li><strong>DX推進:</strong> 行政手続きのオンライン化とデータ活用で、県民の負担を軽減します。</li>
+            </ul>
+        </div>
+    </section>
+
+    <section id="policy-nextgen" class="section bg-light policy-section">
+        <div class="container">
+            <h2 class="section-title text-left">次世代の声を県政へ</h2>
+            <p class="policy-text">
+                若い世代が県政に参加できる仕組みを整え、<strong>「声が届く政治」</strong>を実現します。
+            </p>
+            <ul class="policy-list">
+                <li><strong>若者議会の設置:</strong> 高校・大学生を中心に政策提言の場をつくり、意見を県政に反映します。</li>
+                <li><strong>広聴機能の強化:</strong> SNSやオンライン対話を活用し、日常的に意見を集める仕組みを整備します。</li>
+                <li><strong>投票しやすい環境:</strong> 期日前投票の拡充や啓発活動を強化し、政治参加のハードルを下げます。</li>
+            </ul>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container footer-content">
+            <div class="footer-info">
+                <h3>小西政宏 後援会事務所</h3>
+                <p>〒648-0000 和歌山県橋本市〇〇町 1-2-3</p>
+                <p>TEL: 0736-XX-XXXX</p>
+            </div>
+            <div class="footer-links">
+                <ul class="footer-nav">
+                    <li><a href="#">プライバシーポリシー</a></li>
+                    <li><a href="index.html#contact">お問い合わせ</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="copyright">
+            &copy; 2025 Masahiro Konishi. All Rights Reserved.
+        </div>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a new “ご挨拶” (greeting) section to the homepage to provide a personal introduction between the timeline and profile areas.
- Expand the brief policy overview into a dedicated details page so visitors can read full policy text for each of the four pillars.
- Improve navigation and multi-page behavior so the site supports a separate `policy.html` while keeping the existing layout and accessibility patterns.

### Description
- Updated `index.html` to add a `section#greeting`, change the navigation “政策” link to `policy.html`, and add “詳しく見る” buttons linking to anchors in the new page.
- Added `policy.html` containing SEO metadata (`<title>` and `<meta name="description">`), top anchor links and four anchored sections (`#policy-education`, `#policy-economy`, `#policy-reform`, `#policy-nextgen`) with structured policy content.
- Extended `css/styles.css` with styles for the greeting area, responsive layout adjustments, and policy-page specific classes (e.g. `.page-hero`, `.policy-section`) while keeping the existing color palette.
- Hardened `js/script.js` by guarding hamburger/menu and modal code for multi-page usage and retained smooth-scroll, tabs, filters and form-submit behaviors to ensure cross-page stability.

### Testing
- Served the site locally with `python -m http.server` and loaded `index.html` and `policy.html` in headless Chromium via Playwright to capture full-page screenshots, which completed successfully.
- No automated unit tests were present or executed for these static changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c79ad058832da0b03b7687810a04)