### PR TITLE
Update homepage: replace works with Instagram link, remove support section, update office contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
                     <li><a href="policy.html">政策</a></li>
                     <li><a href="#works">実績</a></li>
                     <li><a href="#news">活動報告</a></li>
-                    <li><a href="#support">応援</a></li>
                     <li><a href="#contact">お問い合わせ</a></li>
                 </ul>
             </nav>
@@ -195,44 +194,9 @@
 
     <section id="works" class="section bg-light">
         <div class="container">
-            <h2 class="section-title">これまでの主な実績</h2>
-            <div class="tabs">
-                <button class="tab-btn active" data-target="works-city">市議会での実績</button>
-                <button class="tab-btn" data-target="works-pref">県議会での取り組み</button>
-            </div>
-
-            <div id="works-city" class="tab-content active">
-                <div class="grid-3">
-                    <div class="card work-card">
-                        <h3>公共施設のコスト削減</h3>
-                        <p>電気料金プランの見直しを提案し、年間数百万円規模の削減を実現しました。</p>
-                    </div>
-                    <div class="card work-card">
-                        <h3>草刈り業務の効率化</h3>
-                        <p>民間委託の適正化を推進し、維持管理コストを抑えつつ美観を向上。</p>
-                    </div>
-                    <div class="card work-card">
-                        <h3>中学校給食の導入推進</h3>
-                        <p>子育て世帯の負担軽減のため、完全給食化に向けた議論をリード。</p>
-                    </div>
-                </div>
-            </div>
-
-            <div id="works-pref" class="tab-content">
-                <div class="grid-3">
-                    <div class="card work-card">
-                        <h3>制服リユースの促進</h3>
-                        <p>県内の学校における制服リユースバンクの仕組み作りを支援。</p>
-                    </div>
-                    <div class="card work-card">
-                        <h3>女子制服スラックス導入</h3>
-                        <p>多様性を尊重し、県立高校でのスラックス選択制導入を加速させました。</p>
-                    </div>
-                    <div class="card work-card">
-                        <h3>大阪・関西万博でのPR</h3>
-                        <p>高野山麓・橋本エリアの観光魅力を万博で発信するための予算確保。</p>
-                    </div>
-                </div>
+            <h2 class="section-title">Instagram</h2>
+            <div class="text-center">
+                <a href="https://www.instagram.com/masahiro.524/" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Instagramはこちら</a>
             </div>
         </div>
     </section>
@@ -265,44 +229,6 @@
                     <h3 class="news-title">小学校の通学路点検を実施</h3>
                     <p class="news-excerpt">保護者の方々からの要望を受け、危険箇所の安全対策を県に要望しました。</p>
                 </article>
-            </div>
-        </div>
-    </section>
-
-    <section id="support" class="section bg-accent">
-        <div class="container">
-            <h2 class="section-title text-white">小西政宏を応援する</h2>
-            <p class="text-white text-center mb-2">私たちと一緒に、和歌山の未来をつくりませんか？<br>少しの時間でも構いません。あなたのお力をお貸しください。</p>
-            
-            <div class="grid-4 mb-2">
-                <div class="card support-card"><h3>ポスティング</h3><p>チラシの配布協力</p></div>
-                <div class="card support-card"><h3>事務作業</h3><p>宛名書きや封入作業</p></div>
-                <div class="card support-card"><h3>SNS発信</h3><p>シェア・拡散の協力</p></div>
-                <div class="card support-card"><h3>イベント手伝い</h3><p>集会等の受付・誘導</p></div>
-            </div>
-
-            <div class="form-container">
-                <h3 class="form-title">サポーター登録フォーム</h3>
-                <form id="support-form">
-                    <div class="form-group">
-                        <label for="supporter-name">お名前 <span class="required">必須</span></label>
-                        <input type="text" id="supporter-name" required placeholder="例：和歌山 太郎">
-                    </div>
-                    <div class="form-group">
-                        <label for="supporter-city">お住まいの市町村 <span class="required">必須</span></label>
-                        <input type="text" id="supporter-city" required placeholder="例：橋本市">
-                    </div>
-                    <div class="form-group">
-                        <label>関わりたい内容（複数可）</label>
-                        <div class="checkbox-group">
-                            <label><input type="checkbox" name="role" value="posting"> ポスティング</label>
-                            <label><input type="checkbox" name="role" value="office"> 事務作業</label>
-                            <label><input type="checkbox" name="role" value="sns"> SNS発信</label>
-                        </div>
-                    </div>
-                    <button type="submit" class="btn btn-primary full-width">登録する</button>
-                    <div class="form-message" id="support-msg"></div>
-                </form>
             </div>
         </div>
     </section>
@@ -341,8 +267,8 @@
         <div class="container footer-content">
             <div class="footer-info">
                 <h3>小西政宏 後援会事務所</h3>
-                <p>〒648-0000 和歌山県橋本市〇〇町 1-2-3</p>
-                <p>TEL: 0736-XX-XXXX</p>
+                <p>〒648-0000 和歌山県橋本市市脇4丁目1-20</p>
+                <p>TEL: 0736-25-5801</p>
             </div>
             <div class="footer-links">
                 <ul class="footer-nav">


### PR DESCRIPTION
### Motivation
- Simplify the top page "#works" area to point users to the Instagram account instead of listing prior achievements. 
- Remove the "応援する" (support) section and its navigation entry to declutter the site. 
- Update the footer office address and telephone to the provided, correct contact details. 

### Description
- Replaced the content of the `#works` section with a centered Instagram link to `https://www.instagram.com/masahiro.524/`. 
- Removed the `#support` section HTML and the corresponding navigation item linking to `#support`. 
- Updated the footer contact block to `〒648-0000 和歌山県橋本市市脇4丁目1-20` and `TEL: 0736-25-5801`. 
- Adjusted markup to keep layout intact after removal of the support section. 

### Testing
- Started a local HTTP server with `python -m http.server` and confirmed it served `index.html` successfully. 
- Captured a full-page screenshot using a Playwright script to verify the updated page rendering, which completed successfully. 
- Ran a git commit to record the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963cbb4e8b0832db79ec97bbeef06d9)