### PR TITLE
fix: 各種SNS化と不要リンク削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                     <li><a href="#hero">トップ</a></li>
                     <li><a href="#profile">プロフィール</a></li>
                     <li><a href="policy.html">政策</a></li>
-                    <li><a href="#works">実績</a></li>
+                    <li><a href="#works">各種SNS</a></li>
                 </ul>
             </nav>
         </div>
@@ -237,9 +237,10 @@
 
     <section id="works" class="section bg-light">
         <div class="container">
-            <h2 class="section-title">Instagram</h2>
+            <h2 class="section-title">各種SNS</h2>
             <div class="text-center">
                 <a href="https://www.instagram.com/masahiro.524/" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Instagramはこちら</a>
+                <a href="https://youtube.com/channel/UClWxdS5-oOLa-mZfZ_eyO0A?si=2p1E7ViWnFybij3t" class="btn btn-secondary" target="_blank" rel="noopener noreferrer" style="margin-left: 10px;">YouTubeはこちら</a>
             </div>
         </div>
     </section>
@@ -253,7 +254,6 @@
             </div>
             <div class="footer-links">
                 <ul class="footer-nav">
-                    <li><a href="#">プライバシーポリシー</a></li>
                 </ul>
             </div>
         </div>

--- a/policy.html
+++ b/policy.html
@@ -29,7 +29,7 @@
                     <li><a href="index.html#hero">トップ</a></li>
                     <li><a href="index.html#profile">プロフィール</a></li>
                     <li><a href="policy.html">政策</a></li>
-                    <li><a href="index.html#works">実績</a></li>
+                    <li><a href="index.html#works">各種SNS</a></li>
                 </ul>
             </nav>
         </div>
@@ -187,7 +187,6 @@
             </div>
             <div class="footer-links">
                 <ul class="footer-nav">
-                    <li><a href="index.html#contact">お問い合わせ</a></li>
                     <li><a href="https://drive.google.com/file/d/1YbdmT0dmbDV8NvFA25mbJTmY48W0Y860/view" target="_blank" rel="noopener noreferrer">政策集PDF</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
## 概要
追加依頼分の反映です。

## 変更内容
- フッターのプライバシーポリシー削除
- コンタクト（お問い合わせ）導線削除
- トップセクション名を『各種SNS』へ変更
- Instagramリンクに加えてYouTubeリンクを追加
- ナビ表記を『実績』→『各種SNS』へ変更

## 確認ポイント
- SNSセクションでInstagram/YouTubeの2リンクが表示される
- プライバシーポリシー/お問い合わせリンクが存在しない